### PR TITLE
Workaround to get managed subnets working again

### DIFF
--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -307,7 +307,7 @@ func (v *VPCSpec) IsIPv6Enabled() bool {
 // SubnetSpec configures an AWS Subnet.
 type SubnetSpec struct {
 	// ID defines a unique identifier to reference this resource.
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
 	// CidrBlock is the CIDR block to be used when the provider creates a managed VPC.
 	CidrBlock string `json:"cidrBlock,omitempty"`
@@ -349,8 +349,6 @@ func (s *SubnetSpec) String() string {
 }
 
 // Subnets is a slice of Subnet.
-// +listType=map
-// +listMapKey=id
 type Subnets []SubnetSpec
 
 // ToMap returns a map from id to subnet.

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -371,10 +371,12 @@ func (s Subnets) IDs() []string {
 }
 
 // FindByID returns a single subnet matching the given id or nil.
-func (s Subnets) FindByID(id string) *SubnetSpec {
-	for _, x := range s {
+//
+// The returned pointer can be used to write back into the original slice.
+func (s *Subnets) FindByID(id string) *SubnetSpec {
+	for i, x := range *s {
 		if x.ID == id {
-			return &x
+			return &(*s)[i] // pointer to original structure
 		}
 	}
 
@@ -384,10 +386,12 @@ func (s Subnets) FindByID(id string) *SubnetSpec {
 // FindEqual returns a subnet spec that is equal to the one passed in.
 // Two subnets are defined equal to each other if their id is equal
 // or if they are in the same vpc and the cidr block is the same.
-func (s Subnets) FindEqual(spec *SubnetSpec) *SubnetSpec {
-	for _, x := range s {
+//
+// The returned pointer can be used to write back into the original slice.
+func (s *Subnets) FindEqual(spec *SubnetSpec) *SubnetSpec {
+	for i, x := range *s {
 		if (spec.ID != "" && x.ID == spec.ID) || (spec.CidrBlock == x.CidrBlock) || (spec.IPv6CidrBlock != "" && spec.IPv6CidrBlock == x.IPv6CidrBlock) {
-			return &x
+			return &(*s)[i] // pointer to original structure
 		}
 	}
 	return nil

--- a/cmd/clusterawsadm/converters/cloudformation.go
+++ b/cmd/clusterawsadm/converters/cloudformation.go
@@ -17,6 +17,8 @@ limitations under the License.
 package converters
 
 import (
+	"sort"
+
 	"github.com/awslabs/goformation/v4/cloudformation/tags"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -34,6 +36,9 @@ func MapToCloudFormationTags(src infrav1.Tags) []tags.Tag {
 
 		cfnTags = append(cfnTags, tag)
 	}
+
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(cfnTags, func(i, j int) bool { return cfnTags[i].Key < cfnTags[j].Key })
 
 	return cfnTags
 }

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -446,13 +446,8 @@ spec:
                           description: Tags is a collection of tags describing the
                             resource.
                           type: object
-                      required:
-                      - id
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - id
-                    x-kubernetes-list-type: map
                   vpc:
                     description: VPC configuration.
                     properties:
@@ -1802,13 +1797,8 @@ spec:
                           description: Tags is a collection of tags describing the
                             resource.
                           type: object
-                      required:
-                      - id
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - id
-                    x-kubernetes-list-type: map
                   vpc:
                     description: VPC configuration.
                     properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1173,13 +1173,8 @@ spec:
                           description: Tags is a collection of tags describing the
                             resource.
                           type: object
-                      required:
-                      - id
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - id
-                    x-kubernetes-list-type: map
                   vpc:
                     description: VPC configuration.
                     properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -777,13 +777,8 @@ spec:
                                   description: Tags is a collection of tags describing
                                     the resource.
                                   type: object
-                              required:
-                              - id
                               type: object
                             type: array
-                            x-kubernetes-list-map-keys:
-                            - id
-                            x-kubernetes-list-type: map
                           vpc:
                             description: VPC configuration.
                             properties:

--- a/pkg/cloud/converters/tags.go
+++ b/pkg/cloud/converters/tags.go
@@ -17,6 +17,8 @@ limitations under the License.
 package converters
 
 import (
+	"sort"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -64,6 +66,9 @@ func MapToTags(src infrav1.Tags) []*ec2.Tag {
 		tags = append(tags, tag)
 	}
 
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 
@@ -102,6 +107,9 @@ func MapToELBTags(src infrav1.Tags) []*elb.Tag {
 		tags = append(tags, tag)
 	}
 
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 
@@ -117,6 +125,9 @@ func MapToV2Tags(src infrav1.Tags) []*elbv2.Tag {
 
 		tags = append(tags, tag)
 	}
+
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
 
 	return tags
 }
@@ -134,6 +145,9 @@ func MapToSecretsManagerTags(src infrav1.Tags) []*secretsmanager.Tag {
 		tags = append(tags, tag)
 	}
 
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 
@@ -150,6 +164,9 @@ func MapToSSMTags(src infrav1.Tags) []*ssm.Tag {
 		tags = append(tags, tag)
 	}
 
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 
@@ -165,6 +182,9 @@ func MapToIAMTags(src infrav1.Tags) []*iam.Tag {
 
 		tags = append(tags, tag)
 	}
+
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
 
 	return tags
 }

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -18,6 +18,7 @@ package asg
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -415,6 +416,9 @@ func BuildTagsFromMap(asgName string, inTags map[string]string) []*autoscaling.T
 		})
 	}
 
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 
@@ -493,6 +497,10 @@ func mapToTags(input map[string]string, resourceID *string) []*autoscaling.Tag {
 			Value:             aws.String(v),
 		})
 	}
+
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -806,6 +806,8 @@ func (s *Service) buildLaunchTemplateTagSpecificationRequest(scope scope.LaunchT
 				Value: aws.String(value),
 			})
 		}
+		// Sort so that unit tests can expect a stable order
+		sort.Slice(spec.Tags, func(i, j int) bool { return *spec.Tags[i].Key < *spec.Tags[j].Key })
 		tagSpecifications = append(tagSpecifications, spec)
 
 		// tag EBS volumes
@@ -816,6 +818,8 @@ func (s *Service) buildLaunchTemplateTagSpecificationRequest(scope scope.LaunchT
 				Value: aws.String(value),
 			})
 		}
+		// Sort so that unit tests can expect a stable order
+		sort.Slice(spec.Tags, func(i, j int) bool { return *spec.Tags[i].Key < *spec.Tags[j].Key })
 		tagSpecifications = append(tagSpecifications, spec)
 	}
 	return tagSpecifications

--- a/pkg/cloud/services/eks/iam/iam.go
+++ b/pkg/cloud/services/eks/iam/iam.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -174,6 +175,10 @@ func RoleTags(key string, additionalTags infrav1.Tags) []*iam.Tag {
 			Value: aws.String(v),
 		})
 	}
+
+	// Sort so that unit tests can expect a stable order
+	sort.Slice(tags, func(i, j int) bool { return *tags[i].Key < *tags[j].Key })
+
 	return tags
 }
 

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -698,20 +698,18 @@ func (s *Service) RegisterInstanceWithAPIServerELB(i *infrav1.Instance) error {
 	}
 
 	// Validate that the subnets associated with the load balancer has the instance AZ.
-	subnet := s.scope.Subnets().FindByID(i.SubnetID)
-	if subnet == nil {
+	subnets := s.scope.Subnets()
+	instanceSubnet := subnets.FindByID(i.SubnetID)
+	if instanceSubnet == nil {
 		return errors.Errorf("failed to attach load balancer subnets, could not find subnet %q description in AWSCluster", i.SubnetID)
 	}
-	instanceAZ := subnet.AvailabilityZone
+	instanceAZ := instanceSubnet.AvailabilityZone
 
-	var subnets infrav1.Subnets
 	if s.scope.ControlPlaneLoadBalancer() != nil && len(s.scope.ControlPlaneLoadBalancer().Subnets) > 0 {
 		subnets, err = s.getControlPlaneLoadBalancerSubnets()
 		if err != nil {
 			return err
 		}
-	} else {
-		subnets = s.scope.Subnets()
 	}
 
 	found := false

--- a/pkg/cloud/services/network/natgateways.go
+++ b/pkg/cloud/services/network/natgateways.go
@@ -107,8 +107,12 @@ func (s *Service) reconcileNatGateways() error {
 		}
 		ngws, err := s.createNatGateways(subnetIDs)
 
+		subnets := s.scope.Subnets()
+		defer func() {
+			s.scope.SetSubnets(subnets)
+		}()
 		for _, ng := range ngws {
-			subnet := s.scope.Subnets().FindByID(*ng.SubnetId)
+			subnet := subnets.FindByID(*ng.SubnetId)
 			subnet.NatGatewayID = ng.NatGatewayId
 		}
 

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -52,8 +52,12 @@ func (s *Service) reconcileRouteTables() error {
 	}
 
 	subnets := s.scope.Subnets()
+	defer func() {
+		s.scope.SetSubnets(subnets)
+	}()
+
 	for i := range subnets {
-		sn := subnets[i]
+		sn := &subnets[i]
 		// We need to compile the minimum routes for this subnet first, so we can compare it or create them.
 		var routes []*ec2.Route
 		if sn.IsPublic {
@@ -65,7 +69,7 @@ func (s *Service) reconcileRouteTables() error {
 				routes = append(routes, s.getGatewayPublicIPv6Route())
 			}
 		} else {
-			natGatewayID, err := s.getNatGatewayForSubnet(&sn)
+			natGatewayID, err := s.getNatGatewayForSubnet(sn)
 			if err != nil {
 				return err
 			}

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -141,7 +141,7 @@ func (s *Service) reconcileSubnets() error {
 		} else if unmanagedVPC {
 			// If there is no existing subnet and we have an umanaged vpc report an error
 			record.Warnf(s.scope.InfraCluster(), "FailedMatchSubnet", "Using unmanaged VPC and failed to find existing subnet for specified subnet id %d, cidr %q", sub.ID, sub.CidrBlock)
-			return errors.New(fmt.Errorf("usign unmanaged vpc and subnet %s (cidr %s) specified but it doesn't exist in vpc %s", sub.ID, sub.CidrBlock, s.scope.VPC().ID).Error())
+			return errors.New(fmt.Errorf("using unmanaged vpc and subnet %s (cidr %s) specified but it doesn't exist in vpc %s", sub.ID, sub.CidrBlock, s.scope.VPC().ID).Error())
 		}
 	}
 

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -104,6 +104,7 @@ providers:
           - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-limit-az.yaml"
           - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-machine-pool.yaml"
           - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-md-remediation.yaml"
+          - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-multi-az.yaml"
           - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-nested-multitenancy.yaml"
           - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-remote-management-cluster.yaml"
           - sourcePath: "./infrastructure-aws/withoutclusterclass/generated/cluster-template-simple-multitenancy.yaml"

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/multi-az/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/multi-az/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../default
+patchesStrategicMerge:
+  - patches/multi-az.yaml

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/multi-az/patches/multi-az.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/multi-az/patches/multi-az.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  network:
+    subnets:
+      - availabilityZone: "${AWS_AVAILABILITY_ZONE_1}"
+        cidrBlock: "10.0.0.0/24"
+      - availabilityZone: "${AWS_AVAILABILITY_ZONE_1}"
+        cidrBlock: "10.0.1.0/24"
+        isPublic: true
+      - availabilityZone: "${AWS_AVAILABILITY_ZONE_2}"
+        cidrBlock: "10.0.2.0/24"
+      - availabilityZone: "${AWS_AVAILABILITY_ZONE_2}"
+        cidrBlock: "10.0.3.0/24"
+        isPublic: true

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -49,6 +49,7 @@ const (
 	AwsNodeMachineType                   = "AWS_NODE_MACHINE_TYPE"
 	AwsAvailabilityZone1                 = "AWS_AVAILABILITY_ZONE_1"
 	AwsAvailabilityZone2                 = "AWS_AVAILABILITY_ZONE_2"
+	MultiAzFlavor                        = "multi-az"
 	LimitAzFlavor                        = "limit-az"
 	SpotInstancesFlavor                  = "spot-instances"
 	SSMFlavor                            = "ssm"

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -22,6 +22,7 @@ package unmanaged
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -545,6 +546,51 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				azError := "Failed to create instance: no subnets available in availability zone \"%s\""
 				return isErrorEventExists(namespace.Name, md2Name, "FailedCreate", fmt.Sprintf(azError, *invalidAz), eventList)
 			}, e2eCtx.E2EConfig.GetIntervals("", "wait-worker-nodes")...).Should(BeTrue())
+		})
+	})
+
+	ginkgo.Describe("Workload cluster in multiple AZs", func() {
+		ginkgo.It("It should be creatable and deletable", func() {
+			specName := "functional-test-multi-az"
+			requiredResources = &shared.TestResource{EC2Normal: 3 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3}
+			requiredResources.WriteRequestedResources(e2eCtx, specName)
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			defer shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+			namespace := shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+			defer shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+			ginkgo.By("Creating a cluster")
+			clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+			configCluster := defaultConfigCluster(clusterName, namespace.Name)
+			configCluster.ControlPlaneMachineCount = pointer.Int64Ptr(3)
+			configCluster.Flavor = shared.MultiAzFlavor
+			cluster, _, _ := createCluster(ctx, configCluster, result)
+
+			ginkgo.By("Adding worker nodes to additional subnets")
+			mdName1 := clusterName + "-md-1"
+			mdName2 := clusterName + "-md-2"
+			md1 := makeMachineDeployment(namespace.Name, mdName1, clusterName, 1)
+			md2 := makeMachineDeployment(namespace.Name, mdName2, clusterName, 1)
+			az1 := os.Getenv(shared.AwsAvailabilityZone1)
+			az2 := os.Getenv(shared.AwsAvailabilityZone2)
+
+			// private CIDRs set in cluster-template-multi-az.yaml.
+			framework.CreateMachineDeployment(ctx, framework.CreateMachineDeploymentInput{
+				Creator:                 e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				MachineDeployment:       md1,
+				BootstrapConfigTemplate: makeJoinBootstrapConfigTemplate(namespace.Name, mdName1),
+				InfraMachineTemplate:    makeAWSMachineTemplate(namespace.Name, mdName1, e2eCtx.E2EConfig.GetVariable(shared.AwsNodeMachineType), pointer.StringPtr(az1), getSubnetID("cidr-block", "10.0.0.0/24", clusterName)),
+			})
+			framework.CreateMachineDeployment(ctx, framework.CreateMachineDeploymentInput{
+				Creator:                 e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				MachineDeployment:       md2,
+				BootstrapConfigTemplate: makeJoinBootstrapConfigTemplate(namespace.Name, mdName2),
+				InfraMachineTemplate:    makeAWSMachineTemplate(namespace.Name, mdName2, e2eCtx.E2EConfig.GetVariable(shared.AwsNodeMachineType), pointer.StringPtr(az2), getSubnetID("cidr-block", "10.0.2.0/24", clusterName)),
+			})
+
+			ginkgo.By("Waiting for new worker nodes to become ready")
+			k8sClient := e2eCtx.Environment.BootstrapClusterProxy.GetClient()
+			framework.WaitForMachineDeploymentNodesToExist(ctx, framework.WaitForMachineDeploymentNodesToExistInput{Lister: k8sClient, Cluster: cluster, MachineDeployment: md1}, e2eCtx.E2EConfig.GetIntervals("", "wait-worker-nodes")...)
+			framework.WaitForMachineDeploymentNodesToExist(ctx, framework.WaitForMachineDeploymentNodesToExistInput{Lister: k8sClient, Cluster: cluster, MachineDeployment: md2}, e2eCtx.E2EConfig.GetIntervals("", "wait-worker-nodes")...)
 		})
 	})
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1932 and https://github.com/giantswarm/roadmap/issues/1832

We decided that we want to revert the buggy upstream change. I did that in separate commits, so it should be easy to see where the changes come from. On top, I added a unit test which covers all AWS API calls throughout full reconciliation of a `AWSCluster` with managed VPC and subnets. My suggestion for reviewers is to look at commits oldest-to-newest. Note how my unit test found a few issues such as not writing latest information back to memory – those points are fixed and reconciliation should now run smoother, in one run.

After the workaround, we will invest time into the larger upstream issue https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4026 where a networking rewrite draft shall be written before getting into implementation. The outcome should be the same: managed subnets working again. That might look different from the solution in this PR, such as introducing new `AWS*` CRs or versions, but I assume that we don't diverge a lot with this workaround, and that it will be easy to migrate to a fixed upstream version in the future.

P.S. I want to merge, not squash, these commits. Otherwise we cannot see anymore which parts are reverts of upstream commits vs. what I added.