### PR TITLE
Adapt main branch in our fork to build images and create GitHub releases from tags, update development instructions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,27 +11,10 @@ jobs:
       REGISTRY_CHINA: giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm
     steps:
       - checkout
+
       - run:
-          name: Build the CAPI docker images
+          name: Build the CAPA docker images
           command: |
-            # Add release manifest to our Docker image. These are used by
-            # https://github.com/giantswarm/cluster-api-provider-aws-app to fetch CRD manifests. We don't create
-            # GitHub releases as https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases, so our fork
-            # uses this alternative way of providing the files.
-            awk '
-                /RUN.*go-build/ {
-                    print "RUN make release-manifests RELEASE_TAG=REPLACE_ME_RELEASE_TAG REGISTRY=REPLACE_ME_REGISTRY"
-                }
-                /COPY --from=builder \/workspace\/manager/ {
-                    print "COPY --from=builder /workspace/out/infrastructure-components.yaml /for-cluster-api-provider-aws-app-only/infrastructure-components.yaml"
-                }
-
-                { print }
-                ' Dockerfile >/tmp/Dockerfile && mv /tmp/Dockerfile Dockerfile
-            # `make release-manifests` needs `config/`, `hack/`, `Makefile` and probably more, so just copy
-            # everything into the Docker context
-            rm .dockerignore
-
             for registry in $REGISTRY_QUAY $REGISTRY_CHINA; do
               make docker-build-all ALL_ARCH="$ALL_ARCH" TAG=$CIRCLE_SHA1 REGISTRY=$registry
 
@@ -40,6 +23,7 @@ jobs:
                 make docker-build-all ALL_ARCH="$ALL_ARCH" TAG="$CIRCLE_TAG" REGISTRY=$registry
               fi
             done
+
       - run:
           name: Push to quay
           command: |
@@ -66,7 +50,7 @@ jobs:
                   echo "Pushing tag $CIRCLE_TAG"
                   make docker-push-all ALL_ARCH="$ALL_ARCH" TAG="$CIRCLE_TAG" REGISTRY=$REGISTRY_CHINA
                 fi
-              ) || { echo "Failed attempt ${n}"; continue; }
+              ) || { echo "Failed attempt ${n}"; sleep 30; continue; }
 
               echo "Succeeded in attempt ${n}"
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+# As opposed to https://github.com/kubernetes-sigs/cluster-api (CAPI), the CAPA upstream project does not offer
+# a GitHub action to automatically create releases from tags (as of 2023-08-21). Therefore, this is a Giant Swarm
+# fork-specific addition. We require a GitHub release containing the YAML manifests which we use in
+# cluster-api-provider-aws-app. Since doing this manually is very error-prone (see
+# `docs/book/src/development/releasing.md`), we run the needed commands here.
+
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # allow creating a release
+
+jobs:
+  build:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    env:
+      GH_ORG_NAME: giantswarm
+    steps:
+      - name: Set env
+        run: |
+          if echo "${GITHUB_REF}" | grep -qF "vX.Y"; then
+            >&2 echo "ERROR: Oops, you copy-pasted verbatim from the README.md - please ensure to replace 'vX.Y.Z' with an actual tag"
+            exit 1
+          fi
+
+          echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV # strip off `refs/tags/` prefix
+
+      - name: Check out code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag=v3.5.0
+        with:
+          fetch-depth: 0
+
+      # - name: Calculate Go version
+      #   run: echo "go_version=$(make go-version)" >> $GITHUB_ENV
+
+      # - name: Set up Go
+      #   uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
+      #   with:
+      #     go-version: ${{ env.go_version }}
+
+      - name: Generate release artifacts
+        run: |
+          # Dealing with changelogs isn't that easy since Giant Swarm releases can jump from `v2.2.0` to `v2.3.1`
+          # as we skip intermediate releases. Therefore, finding the required value for `PREVIOUS_VERSION` would be
+          # a manual task. Better not deal with the changelog right now since it's unlikely that someone will look
+          # at those in our fork (as compared to upstream's releases).
+          printf '#!/bin/sh\necho "Changelogs are not filled in this fork"\n' > hack/releasechangelog.sh
+
+          # We don't need the binaries and other stuff in the release, either. Really only the YAML manifests.
+          sed -i -E -e '/\$\(MAKE\) (release-binaries|release-templates|release-policies)/d' Makefile
+
+          # To allow the above changes since normally the Makefile wouldn't allow a dirty Git repo
+          sed -i -e '/Your local git repository contains uncommitted changes/d' Makefile
+
+          (set -x; make RELEASE_TAG="${RELEASE_TAG}" release)
+
+      # Instead of `make VERSION="${RELEASE_TAG}" create-gh-release upload-gh-artifacts`, which requires GitHub CLI
+      # authentication, use an action which does the same.
+      - name: Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag=v1
+        with:
+          draft: true
+          files: out/*
+          body: "This fork does not provide release changelogs."
+          # `name` not needed since this takes the tag by default (which we also use above as ${RELEASE_TAG})

--- a/README.md
+++ b/README.md
@@ -1,224 +1,112 @@
-# Kubernetes Cluster API Provider AWS
+# Cluster API Provider AWS
 
-<p align="center">
-<img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png"  width="100x"><a href="https://aws.amazon.com/opensource/"><img width="192x" src="https://d0.awsstatic.com/logos/powered-by-aws.png" alt="Powered by AWS Cloud Computing"></a>
-</p>
-<p align="center">
-<!-- go doc / reference card -->
-<a href="https://godoc.org/sigs.k8s.io/cluster-api-provider-aws">
-<img src="https://godoc.org/sigs.k8s.io/cluster-api-provider-aws?status.svg"></a>
-<!-- goreportcard badge -->
-<a href="https://goreportcard.com/report/sigs.k8s.io/cluster-api-provider-aws">
-<img src="https://goreportcard.com/badge/sigs.k8s.io/cluster-api-provider-aws"></a>
-<!-- join kubernetes slack channel for cluster-api-aws-provider -->
-<a href="http://slack.k8s.io/">
-<img src="https://img.shields.io/badge/join%20slack-%23cluster--api--aws-brightgreen"></a>
-<!-- openssf badge -->
-<a href="https://bestpractices.coreinfrastructure.org/projects/5688">
-<img src="https://bestpractices.coreinfrastructure.org/projects/5688/badge"></a>
-</p>
+This is Giant Swarm's fork. See the upstream [cluster-api-provider-aws README](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/README.md) for official documentation.
 
-------
+## How to work with this repo
 
-Kubernetes-native declarative infrastructure for AWS.
+Currently, we try to follow the upstream `release-X.Y` branch to always get the latest stable release and fixes, but not untested commits from `main`. Our only differences against upstream should be in this `README.md`, `.circleci/` and `.github/workflows/release.yml`. Other changes should be opened as PR for the upstream project first.
 
-## What is the Cluster API Provider AWS
+We release cluster-api-provider-aws versions with [cluster-api-provider-aws-app](https://github.com/giantswarm/cluster-api-provider-aws-app/). To provide the YAML manifests, we use GitHub releases as the upstream project. The scripts in `cluster-api-provider-aws-app` convert them into the final manifests.
 
-The [Cluster API][cluster_api] brings
-declarative, Kubernetes-style APIs to cluster creation, configuration and
-management.
+### Repo setup
 
-The API itself is shared across multiple cloud providers allowing for true AWS
-hybrid deployments of Kubernetes. It is built atop the lessons learned from
-previous cluster managers such as [kops][kops] and
-[kubicorn][kubicorn].
+Since we follow upstream, add their Git repo as remote from which we merge commits:
 
-## Documentation
-
-Please see our [book](https://cluster-api-aws.sigs.k8s.io) for in-depth documentation.
-
-## Launching a Kubernetes cluster on AWS
-
-Check out the [Cluster API Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html) for launching a
-cluster on AWS.
-
-## Features
-
-- Native Kubernetes manifests and API
-- Manages the bootstrapping of VPCs, gateways, security groups and instances.
-- Choice of Linux distribution among Amazon Linux 2, CentOS 7, Ubuntu(18.04, 20.04) and Flatcar
-  using [pre-baked AMIs][published_amis].
-- Deploys Kubernetes control planes into private subnets with a separate
-  bastion server.
-- Doesn't use SSH for bootstrapping nodes.
-- Installs only the minimal components to bootstrap a control plane and workers.
-- Supports control planes on EC2 instances.
-- [EKS support][eks_support]
-
-------
-
-## Compatibility with Cluster API and Kubernetes Versions
-
-This provider's versions are compatible with the following versions of Cluster API
-and support all Kubernetes versions that is supported by its compatible Cluster API version:
-
-|                             | Cluster API v1alpha4 (v0.4) | Cluster API v1beta1 (v1.x)  |
-| --------------------------- | :-------------------------: | :-------------------------: |
-| CAPA v1alpha4 `(v0.7)`      |              ✓              |              ☓              |
-| CAPA v1beta1  `(v1.x)`      |              ☓              |               ✓             |
-| CAPA v1beta2  `(v2.x, main)`|              ☓              |               ✓             |
-
-(See [Kubernetes support matrix][cluster-api-supported-v] of Cluster API versions).
-
-------
-
-## Kubernetes versions with published AMIs
-
-See [amis] for the list of most recently published AMIs.
-
-------
-
-## clusterawsadm
-
-`clusterawsadm` CLI tool provides bootstrapping, AMI, EKS, and controller related helpers.
-
-`clusterawsadm` binaries are released with each release, can be found under [assets](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest) section.
-
-`clusterawsadm` could also be installed via Homebrew on macOS and linux OS.
-Install the latest release using homebrew:
-```shell
-brew install clusterawsadm
+```sh
+git clone git@github.com:giantswarm/cluster-api-provider-aws.git
+cd cluster-api-provider-aws
+git remote add upstream https://github.com/kubernetes-sigs/cluster-api-provider-aws.git
 ```
 
-Test to ensure the version you installed is up-to-date:
-```shell
-clusterawsadm version
+### Test and release
+
+If you have a non-urgent fix, create an upstream PR and wait until it gets released. We call this release `vX.Y.Z` in the below instructions, so please fill in the desired tag.
+
+Please follow the development workflow:
+
+- Ensure a stable release branch exists in our fork repo. For example with a desired upstream release v2.2.1, the branch is `release-2.2`. If it does not exist on our side yet, copy the branch from upstream and add our changes such as `README.md` and `.circleci/` on top.
+- Create a working branch for your changes
+- We want to use stable upstream release tags unless a hotfix is absolutely required ([decision](https://intranet.giantswarm.io/docs/product/pdr/010_fork_management/)). Please decide what type of change you're making:
+
+  - Either: you want to merge and test the latest upstream tag
+
+    ```sh
+    # Get latest changes on our release branch
+    git checkout release-X.Y
+    git pull
+
+    git fetch upstream
+
+    git checkout -b my-working-branch release-X.Y
+
+    # Create a merge commit using upstream's desired release tag (the one we want
+    # to upgrade to).
+    # This creates a commit message such as "Merge tag 'v2.2.1' into release-2.2".
+    git merge --no-ff vX.Y.Z
+
+    # Since we want the combined content of our repo and the upstream Git tag,
+    # we need to create our own tag on the merge commit
+    git tag "vX.Y.Z-gs-$(git rev-parse --short HEAD)"
+
+    # Push your working branch. This triggers image build in CircleCI.
+    git push
+
+    # Push your Giant Swarm tag (assuming `origin` is the Giant Swarm fork).
+    # This triggers the GitHub release action - please continue reading below!
+    git push origin "vX.Y.Z-gs-$(git rev-parse --short HEAD)"
+    ```
+
+  - Or: you want to implement something else, such as working on some issue that we have which is not fixed in upstream yet. Note that for testing changes to upstream, you probably better base your work on the `upstream/main` branch and try your change together with the latest commits from upstream. This also avoids merge conflicts. Maintainers can then help you cherry-pick into their release branches. The latest release branch is usually a bit behind `main`.
+
+    ```sh
+    # Get latest changes on our release branch
+    git checkout release-X.Y
+    git pull
+
+    git checkout -b my-working-branch release-X.Y # or based on `main` instead of `release-X.Y`, see hint above
+
+    # Make some changes and commit as usual
+    git commit
+
+    git tag "vX.Y.Z-gs-$(git rev-parse --short HEAD)"
+
+    # Push your working branch. This triggers image build in CircleCI
+    git push
+
+    # Push your Giant Swarm tag (assuming `origin` is the Giant Swarm fork).
+    # This triggers the GitHub release action - please continue reading below!
+    git push origin "vX.Y.Z-gs-$(git rev-parse --short HEAD)"
+    ```
+
+- Check that the [CircleCI pipeline](https://app.circleci.com/pipelines/github/giantswarm/cluster-api-provider-aws) succeeds for the desired Git tag in order to produce images. If the tag build fails, fix it.
+- Check that the [GitHub release action](https://github.com/giantswarm/cluster-api-provider-aws/actions) for the `vX.Y.Z-gs-...` tag succeeds
+- Edit [that draft GitHub release](https://github.com/giantswarm/cluster-api-provider-aws/releases) and turn it from draft to released. This makes the release's manifest files available on the internet, as used in [cluster-api-provider-aws-app](https://github.com/giantswarm/cluster-api-provider-aws-app).
+- Test the changes in the app
+
+  - Replace `.tag` in [cluster-api-provider-aws-app's `values.yaml`](https://github.com/giantswarm/cluster-api-provider-aws-app/blob/master/helm/cluster-api-provider-aws/values.yaml) with the new tag `vX.Y.Z-gs-...`.
+  - Run `cd cluster-api-provider-aws-app && make generate` to update manifests
+  - Commit and push your working branch for `cluster-api-provider-aws-app` to trigger CircleCI pipeline
+  - Install and test the app thoroughly on a management cluster. Continue with the next step only once you're confident.
+- Open PR for `cluster-api-provider-aws` fork (your working branch)
+
+  - If you merged an upstream release tag, we should target our `release-X.Y` branch with the PR.
+  - On the other hand, if you implemented something else which is not in upstream yet, we should target `upstream/main` so that it first lands in the upstream project, officially approved, tested and released. Afterwards, you would repeat this whole procedure and merge the release that includes your fix. For a quick in-house hotfix, you can alternatively do a quicker PR targeted against our `release-X.Y` branch.
+- Also open PR for `cluster-api-provider-aws-app` change
+- Once merged, manually bump the version in the respective collection to deploy it for one provider (e.g. [capa-app-collection](https://github.com/giantswarm/capa-app-collection/))
+
+### Keep fork customizations up to date
+
+Only `README.md`, `.circleci/` and `.github/workflows/release.yml` should differ between upstream and our fork, so the diff of everything else should be empty, or at worst, contain hotfixes that are not in upstream yet:
+
+```sh
+git fetch upstream
+git diff `# the upstream tag we merged recently` vX.Y.Z..origin/release-X.Y `# our release branch` -- ':!.circleci/' "!.github/workflows/release.yml' ':!README.md'
 ```
 
-------
+And we should also keep our `main` and `release-X.Y` branches in sync, so this diff should be empty:
 
-## Getting involved and contributing
-
-Are you interested in contributing to cluster-api-provider-aws? We, the
-maintainers and community, would love your suggestions, contributions, and help!
-Also, the maintainers can be contacted at any time to learn more about how to get
-involved.
-
-In the interest of getting more new people involved we tag issues with
-[`good first issue`][good_first_issue].
-These are typically issues that have smaller scope but are good ways to start
-to get acquainted with the codebase.
-
-We also encourage ALL active community participants to act as if they are
-maintainers, even if you don't have "official" write permissions. This is a
-community effort, we are here to serve the Kubernetes community. If you have an
-active interest and you want to get involved, you have real power! Don't assume
-that the only people who can get things done around here are the "maintainers".
-
-We also would love to add more "official" maintainers, so show us what you can
-do!
-
-This repository uses the Kubernetes bots.  See a full list of the commands [here][prow].
-
-### Build the images locally
-
-If you want to just build the CAPA containers locally, run
-
-```shell
-  REGISTRY=docker.io/my-reg make docker-build
+```sh
+git diff main..release-X.Y -- .circleci/ .github/workflows/release.yml README.md
 ```
 
-### Tilt-based development environment
-
-See [development][development] section for details.
-
-### Implementer office hours
-
-Maintainers hold office hours every two weeks, with sessions open to all
-developers working on this project.
-
-Office hours are hosted on a zoom video chat every other Monday
-at 09:00 (Pacific) / 12:00 (Eastern) / 17:00 (Europe/London),
-and are published on the [Kubernetes community meetings calendar][gcal].
-
-### Other ways to communicate with the contributors
-
-Please check in with us in the [#cluster-api-aws][slack] channel on Slack.
-
-## Github issues
-
-### Bugs
-
-If you think you have found a bug please follow the instructions below.
-
-- Please spend a small amount of time giving due diligence to the issue tracker. Your issue might be a duplicate.
-- Get the logs from the cluster controllers. Please paste this into your issue.
-- Open a [new issue][new_issue].
-- Remember that users might be searching for your issue in the future, so please give it a meaningful title to help others.
-- Feel free to reach out to the cluster-api community on the [kubernetes slack][slack].
-
-### Tracking new features
-
-We also use the issue tracker to track features. If you have an idea for a feature, or think you can help kops become even more awesome follow the steps below.
-
-- Open a [new issue][new_issue].
-- Remember that users might be searching for your issue in the future, so please
-  give it a meaningful title to help others.
-- Clearly define the use case, using concrete examples. EG: I type `this` and
-  cluster-api-provider-aws does `that`.
-- Some of our larger features will require some design. If you would like to
-  include a technical design for your feature please include it in the issue.
-- After the new feature is well understood, and the design agreed upon, we can
-  start coding the feature. We would love for you to code it. So please open
-  up a **WIP** *(work in progress)* pull request, and happy coding.
-
->“Amazon Web Services, AWS, and the “Powered by AWS” logo materials are
-trademarks of Amazon.com, Inc. or its affiliates in the United States
-and/or other countries."
-
-## Our Contributors
-
-Thank you to all contributors and a special thanks to our current maintainers & reviewers:
-
-| Maintainers                                                      | Reviewers                                                            |
-|------------------------------------------------------------------| -------------------------------------------------------------------- |
-| [@richardcase](https://github.com/richardcase) (from 2020-12-04) | [@shivi28](https://github.com/shivi28) (from 2021-08-27)             |
-| [@Skarlso](https://github.com/Skarlso) (from 2022-10-19)         | [@dthorsen](https://github.com/dthorsen) (from 2020-12-04)           |
-| [@Ankitasw](https://github.com/Ankitasw) (from 2022-10-19)       | [@pydctw](https://github.com/pydctw) (from 2021-12-09)               |
-| [@dlipovetsky](https://github.com/dlipovetsky) (from 2021-10-31) | [@AverageMarcus](https://github.com/AverageMarcus) (from 2022-10-19) |
-|                                                                  | [@luthermonson](https://github.com/luthermonson ) (from 2023-03-08)  |
-
-and the previous/emeritus maintainers & reviewers:
-
-| Emeritus Maintainers                                 | Emeritus Reviewers                                     |
-|------------------------------------------------------|--------------------------------------------------------|
-| [@chuckha](https://github.com/chuckha)               | [@ashish-amarnath](https://github.com/ashish-amarnath) |
-| [@detiber](https://github.com/detiber)               | [@davidewatson](https://github.com/davidewatson)       |
-| [@ncdc](https://github.com/ncdc)                     | [@enxebre](https://github.com/enxebre)                 |
-| [@randomvariable](https://github.com/randomvariable) | [@ingvagabund](https://github.com/ingvagabund)         |
-| [@rudoi](https://github.com/rudoi)                   | [@michaelbeaumont](https://github.com/michaelbeaumont) |
-| [@sedefsavas](https://github.com/sedefsavas)         | [@sethp-nr](https://github.com/sethp-nr)               |
-| [@vincepri](https://github.com/vincepri)             |                                                        | 
-
-All the CAPA contributors:
-
-<p>
-<a href="https://github.com/kubernetes-sigs/cluster-api-provider-aws/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=kubernetes-sigs/cluster-api-provider-aws" />
-</a>
-</p>
-
-<!-- References -->
-[slack]: https://kubernetes.slack.com/messages/CD6U2V71N
-[good_first_issue]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
-[gcal]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
-[prow]: https://go.k8s.io/bot-commands
-[new_issue]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/new
-[cluster_api]: https://github.com/kubernetes-sigs/cluster-api
-[kops]: https://github.com/kubernetes/kops
-[kubicorn]: http://kubicorn.io/
-[amis]: https://cluster-api-aws.sigs.k8s.io/topics/images/amis.html
-[published_amis]: https://cluster-api-aws.sigs.k8s.io/topics/images/built-amis.html
-[eks_support]: https://cluster-api-aws.sigs.k8s.io/topics/eks/index.html
-[cluster-api-supported-v]: https://cluster-api.sigs.k8s.io/reference/versions.html
-[development]: https://cluster-api-aws.sigs.k8s.io/development/development.html
+If this shows any output, please align the `main` branch with the release branches.


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/2561

Same as https://github.com/giantswarm/cluster-api-provider-aws/pull/525 but for the `main` branch. This aligns our own files in both branches such that this diff becomes empty:

```
git diff main..release-2.2 -- .circleci/ .github/workflows/release.yml README.md
```