### PR TITLE
Tag S3 bucket as owned by cluster

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -274,6 +274,7 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 				"s3:PutObject",
 				"s3:DeleteObject",
 				"s3:PutBucketPolicy",
+				"s3:PutBucketTagging",
 			},
 		})
 	}

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -279,6 +279,7 @@ Resources:
           - s3:PutObject
           - s3:DeleteObject
           - s3:PutBucketPolicy
+          - s3:PutBucketTagging
           Effect: Allow
           Resource:
           - arn:*:s3:::cluster-api-provider-aws-*

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -75,6 +75,25 @@ func TestReconcileBucket(t *testing.T) {
 		}
 
 		s3Mock.EXPECT().CreateBucket(gomock.Eq(input)).Return(nil, nil).Times(1)
+
+		taggingInput := &s3svc.PutBucketTaggingInput{
+			Bucket: aws.String(expectedBucketName),
+			Tagging: &s3svc.Tagging{
+				TagSet: []*s3svc.Tag{
+					{
+						Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+						Value: aws.String("owned"),
+					},
+					{
+						Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+						Value: aws.String("node"),
+					},
+				},
+			},
+		}
+
+		s3Mock.EXPECT().PutBucketTagging(gomock.Eq(taggingInput)).Return(nil, nil).Times(1)
+
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -129,6 +148,7 @@ func TestReconcileBucket(t *testing.T) {
 			}
 		}).Return(nil, nil).Times(1)
 
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -150,6 +170,7 @@ func TestReconcileBucket(t *testing.T) {
 		})
 
 		s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(1)
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Do(func(input *s3svc.PutBucketPolicyInput) {
 			if input.Policy == nil {
 				t.Fatalf("Policy must be defined")
@@ -189,6 +210,7 @@ func TestReconcileBucket(t *testing.T) {
 		svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
 		s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(2)
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(2)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(2)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -208,6 +230,7 @@ func TestReconcileBucket(t *testing.T) {
 		err := awserr.New(s3svc.ErrCodeBucketAlreadyOwnedByYou, "err", errors.New("err"))
 
 		s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, err).Times(1)
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -248,6 +271,7 @@ func TestReconcileBucket(t *testing.T) {
 			svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
 			s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(1)
+			s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 
 			mockCtrl := gomock.NewController(t)
 			stsMock := mock_stsiface.NewMockSTSAPI(mockCtrl)
@@ -265,6 +289,7 @@ func TestReconcileBucket(t *testing.T) {
 			svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
 			s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(1)
+			s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 			s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, errors.New("error")).Times(1)
 
 			if err := svc.ReconcileBucket(); err == nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2929

Cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4518 into our `release-2.2` fork branch.

Note that [`giantswarm-aws-account-prerequisites` already has this permission](https://github.com/giantswarm/giantswarm-aws-account-prerequisites/blob/master/capa-controller-role/capa-controller-policy.json) added (recently), so I won't open a related PR on that repo.