### PR TITLE
Use `AdditionalTags` for S3 buckets

### DIFF
--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -248,7 +248,7 @@ func (s *Service) tagBucket(bucketName string) error {
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        nil,
 		Role:        aws.String("node"),
-		Additional:  nil,
+		Additional:  s.scope.AdditionalTags(),
 	})
 
 	for key, value := range tags {

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -81,6 +81,10 @@ func TestReconcileBucket(t *testing.T) {
 			Tagging: &s3svc.Tagging{
 				TagSet: []*s3svc.Tag{
 					{
+						Key:   aws.String("additional"),
+						Value: aws.String("from-aws-cluster"),
+					},
+					{
 						Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
 						Value: aws.String("owned"),
 					},
@@ -776,6 +780,9 @@ func testService(t *testing.T, bucket *infrav1.S3Bucket) (*s3.Service, *mock_s3i
 		AWSCluster: &infrav1.AWSCluster{
 			Spec: infrav1.AWSClusterSpec{
 				S3Bucket: bucket,
+				AdditionalTags: infrav1.Tags{
+					"additional": "from-aws-cluster",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Cherry-pick https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4625 into our fork's `release-2.2` branch so we can immediately use it for https://github.com/giantswarm/roadmap/issues/2929.