### PR TITLE
:bug: EKS - when aws-cni is disabled deleted all resources including helm managed resources

### DIFF
--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -30,10 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -30,12 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/kustomize/api/konfig"
-
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -273,20 +271,16 @@ func (s *Service) deleteResource(ctx context.Context, remoteClient client.Client
 		}
 		s.scope.Debug(fmt.Sprintf("resource %s was not found, no action", key))
 	} else {
-		// resource found, delete if no label or not managed by helm
-		if val, ok := obj.GetLabels()[konfig.ManagedbyLabelKey]; !ok || val != "Helm" {
-			if err := remoteClient.Delete(ctx, obj, &client.DeleteOptions{}); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("deleting %s: %w", key, err)
-				}
-				s.scope.Debug(fmt.Sprintf(
-					"resource %s was not found, not deleted", key))
-			} else {
-				s.scope.Debug(fmt.Sprintf("resource %s was deleted", key))
+		if err := remoteClient.Delete(ctx, obj, &client.DeleteOptions{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("deleting %s: %w", key, err)
 			}
+			s.scope.Debug(fmt.Sprintf(
+				"resource %s was not found, not deleted", key))
 		} else {
-			s.scope.Debug(fmt.Sprintf("resource %s is managed by helm, not deleted", key))
+			s.scope.Debug(fmt.Sprintf("resource %s was deleted", key))
 		}
+
 	}
 
 	return nil


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3105

for now always just delete the aws-node  

I want to merge this fix to allow another team to easily try debug the cillium issue.