### PR TITLE
Filter CNI subnets when creating EKS NodeGroup

### DIFF
--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -102,9 +102,7 @@ type TargetGroupHealthCheck struct {
 // TargetGroupAttribute defines attribute key values for V2 Load Balancer Attributes.
 type TargetGroupAttribute string
 
-var (
-	TargetGroupAttributeEnablePreserveClientIP = "preserve_client_ip.enabled"
-)
+var TargetGroupAttributeEnablePreserveClientIP = "preserve_client_ip.enabled"
 
 // LoadBalancerAttribute defines a set of attributes for a V2 load balancer.
 type LoadBalancerAttribute string
@@ -474,6 +472,15 @@ func (s Subnets) FindEqual(spec *SubnetSpec) *SubnetSpec {
 func (s Subnets) FilterPrivate() (res Subnets) {
 	for _, x := range s {
 		if !x.IsPublic {
+			res = append(res, x)
+		}
+	}
+	return
+}
+
+func (s Subnets) FilterPrimary() (res Subnets) {
+	for _, x := range s {
+		if x.Tags[NameAWSSubnetAssociation] != SecondarySubnetTagValue {
 			res = append(res, x)
 		}
 	}

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -478,6 +478,9 @@ func (s Subnets) FilterPrivate() (res Subnets) {
 	return
 }
 
+// FilterPrimary returns a slice containing all subnets that do not have the
+// sigs.k8s.io/cluster-api-provider-aws/association: secondary tag. These
+// subnets are intended for the CNI.
 func (s Subnets) FilterPrimary() (res Subnets) {
 	for _, x := range s {
 		if x.Tags[NameAWSSubnetAssociation] != SecondarySubnetTagValue {

--- a/pkg/cloud/scope/shared.go
+++ b/pkg/cloud/scope/shared.go
@@ -117,6 +117,7 @@ func (p *defaultSubnetPlacementStrategy) getSubnetsForAZs(azs []string, controlP
 				subnets = subnets.FilterPublic()
 			case expinfrav1.AZSubnetTypePrivate:
 				subnets = subnets.FilterPrivate()
+				subnets = subnets.FilterPrimary()
 			}
 		}
 		if len(subnets) == 0 {


### PR DESCRIPTION
Not really sure about the naming. I suppose `Primary` doesn't really tell you what these subnets are, but then again neither does `secondary`. I suppose the best way to name it is `FilterNonCNI`, but that may be a bit too descriptive. 