### PR TITLE
S3 test fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,26 @@
 version: 2.1
-
+orbs:
+  go: circleci/go@1.11.0
 
 jobs:
+  test:
+    resource_class: large
+    executor:
+      name: go/default
+      tag: "1.22.3"
+    steps:
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - run:
+          command: make setup-envtest
+      - go/save-cache
+      - run:
+          command: make test
+
   build:
     machine:
-      image: "ubuntu-2204:2022.10.2"
+      image: "ubuntu-2204:2024.05.1"
     environment:
       ALL_ARCH: "amd64 arm64"
       REGISTRY_AZURE: gsoci.azurecr.io/giantswarm
@@ -81,3 +97,4 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - test

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	sigs.k8s.io/cluster-api v1.5.3
 	sigs.k8s.io/cluster-api/test v1.5.3
 	sigs.k8s.io/controller-runtime v0.15.1
-	sigs.k8s.io/kustomize/api v0.13.4
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -191,6 +190,7 @@ require (
 	k8s.io/metrics v0.27.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.20.0 // indirect
+	sigs.k8s.io/kustomize/api v0.13.4 // indirect
 	sigs.k8s.io/kustomize/kustomize/v5 v5.0.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -338,6 +338,7 @@ func TestDeleteBucket(t *testing.T) {
 			Bucket: aws.String(bucketName),
 		}
 
+		s3Mock.EXPECT().ListObjectsV2(gomock.Any()).Return(&s3svc.ListObjectsV2Output{}, nil).Times(1)
 		s3Mock.EXPECT().DeleteBucket(input).Return(nil, nil).Times(1)
 
 		if err := svc.DeleteBucket(); err != nil {
@@ -352,6 +353,7 @@ func TestDeleteBucket(t *testing.T) {
 
 			svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
+			s3Mock.EXPECT().ListObjectsV2(gomock.Any()).Return(&s3svc.ListObjectsV2Output{}, nil).Times(1)
 			s3Mock.EXPECT().DeleteBucket(gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
 			if err := svc.DeleteBucket(); err == nil {
@@ -364,6 +366,7 @@ func TestDeleteBucket(t *testing.T) {
 
 			svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
+			s3Mock.EXPECT().ListObjectsV2(gomock.Any()).Return(&s3svc.ListObjectsV2Output{}, nil).Times(1)
 			s3Mock.EXPECT().DeleteBucket(gomock.Any()).Return(nil, awserr.New("foo", "", nil)).Times(1)
 
 			if err := svc.DeleteBucket(); err == nil {
@@ -377,6 +380,7 @@ func TestDeleteBucket(t *testing.T) {
 
 		svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
+		s3Mock.EXPECT().ListObjectsV2(gomock.Any()).Return(&s3svc.ListObjectsV2Output{}, nil).Times(1)
 		s3Mock.EXPECT().DeleteBucket(gomock.Any()).Return(nil, awserr.New(s3svc.ErrCodeNoSuchBucket, "", nil)).Times(1)
 
 		if err := svc.DeleteBucket(); err != nil {
@@ -389,6 +393,7 @@ func TestDeleteBucket(t *testing.T) {
 
 		svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
+		s3Mock.EXPECT().ListObjectsV2(gomock.Any()).Return(&s3svc.ListObjectsV2Output{}, nil).Times(1)
 		s3Mock.EXPECT().DeleteBucket(gomock.Any()).Return(nil, awserr.New("BucketNotEmpty", "", nil)).Times(1)
 
 		if err := svc.DeleteBucket(); err != nil {


### PR DESCRIPTION
For some reason, CI went through in #593 and therefore the test failure wasn't detected. @fiunchinho found this fix missing in `release-2.4` as well (see https://github.com/giantswarm/cluster-api-provider-aws/pull/595/files).