### PR TITLE
Use newer CircleCI config from `release-2.4` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,29 @@
 version: 2.1
-
+orbs:
+  go: circleci/go@1.11.0
 
 jobs:
+  test:
+    resource_class: large
+    executor:
+      name: go/default
+      tag: "1.22.3"
+    steps:
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - run:
+          command: make setup-envtest
+      - go/save-cache
+      - run:
+          command: make test
+
   build:
     machine:
-      image: "ubuntu-2204:2022.10.2"
+      image: "ubuntu-2204:2024.05.1"
     environment:
       ALL_ARCH: "amd64 arm64"
+      REGISTRY_AZURE: gsoci.azurecr.io/giantswarm
       REGISTRY_QUAY: quay.io/giantswarm
       REGISTRY_CHINA: giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm
     steps:
@@ -15,7 +32,7 @@ jobs:
       - run:
           name: Build the CAPA docker images
           command: |
-            for registry in $REGISTRY_QUAY $REGISTRY_CHINA; do
+            for registry in $REGISTRY_AZURE $REGISTRY_QUAY $REGISTRY_CHINA; do
               make docker-build-all ALL_ARCH="$ALL_ARCH" TAG=$CIRCLE_SHA1 REGISTRY=$registry
 
               if [ -n "$CIRCLE_TAG" ]; then
@@ -23,6 +40,18 @@ jobs:
                 make docker-build-all ALL_ARCH="$ALL_ARCH" TAG="$CIRCLE_TAG" REGISTRY=$registry
               fi
             done
+
+      - run:
+          name: Push to Azure
+          command: |
+            docker login --username $ACR_GSOCI_USERNAME --password $ACR_GSOCI_PASSWORD "${REGISTRY_AZURE%/*}"
+
+            make docker-push-all ALL_ARCH="$ALL_ARCH" TAG=$CIRCLE_SHA1 REGISTRY=$REGISTRY_AZURE
+
+            if [ -n "$CIRCLE_TAG" ]; then
+              echo "Pushing tag $CIRCLE_TAG"
+              make docker-push-all ALL_ARCH="$ALL_ARCH" TAG="$CIRCLE_TAG" REGISTRY=$REGISTRY_AZURE
+            fi
 
       - run:
           name: Push to quay
@@ -68,3 +97,4 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - test


### PR DESCRIPTION
This makes the diff

```
git diff main..release-2.4 -- .circleci/ .github/workflows/release.yml README.md
```

empty again.

We should also update our `main` branch altogether, but that's another story.