### PR TITLE
Fix subtests running in same environment and reconciliation bug which was not covered because of that

### DIFF
--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -199,7 +199,9 @@ func (s *Service) ReconcileLaunchTemplate(
 			return nil, err
 		}
 		scope.SetLaunchTemplateLatestVersionStatus(launchTemplateVersion)
-		return nil, scope.PatchObject()
+		if err = scope.PatchObject(); err != nil {
+			return nil, err
+		}
 	}
 
 	annotation, err := MachinePoolAnnotationJSON(scope, TagsLastAppliedAnnotation)


### PR DESCRIPTION
Same as #602, ported to `release-2.4` branch