### PR TITLE
Fix Giant Swarm fork release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,40 +30,24 @@ jobs:
 
           echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV # strip off `refs/tags/` prefix
 
-      - name: Check out code
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag=v3.5.0
+      - name: checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # - name: Calculate Go version
-      #   run: echo "go_version=$(make go-version)" >> $GITHUB_ENV
-
-      # - name: Set up Go
-      #   uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
-      #   with:
-      #     go-version: ${{ env.go_version }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: |
+            ./go.sum
+            ./hack/tools/go.sum
 
       - name: Generate release artifacts
         env:
           GITHUB_TOKEN: "unused" # since we create the release without using CAPA's Makefile target
         run: |
-          # Dealing with changelogs isn't that easy since Giant Swarm releases can jump from `v2.2.0` to `v2.3.1`
-          # as we skip intermediate releases. Therefore, finding the required value for `PREVIOUS_VERSION` would be
-          # a manual task. Better not deal with the changelog right now since it's unlikely that someone will look
-          # at those in our fork (as compared to upstream's releases).
-          printf '#!/bin/sh\necho "Changelogs are not filled in this fork"\n' > hack/releasechangelog.sh # old path of this tool
-          mkdir -p hack/tools/bin
-          printf '#!/bin/sh\necho "Changelogs are not filled in this fork" > out/CHANGELOG.md\n' > hack/tools/bin/release-notes
-          chmod +x hack/tools/bin/release-notes
-
-          # We don't need the binaries and other stuff in the release, either. Really only the YAML manifests.
-          sed -i -E -e '/\$\(MAKE\) (release-binaries|release-templates|release-policies)/d' Makefile
-          sed -i -E -e '/cp metadata.yaml/d' Makefile
-
-          # To allow the above changes since normally the Makefile wouldn't allow a dirty Git repo
-          sed -i -e '/Your local git repository contains uncommitted changes/d' Makefile
-
-          (set -x; make PREVIOUS_VERSION="${RELEASE_TAG}" RELEASE_TAG="${RELEASE_TAG}" release)
+          make REGISTRY="registry.k8s.io/cluster-api-aws" RELEASE_TAG="${RELEASE_TAG}" release-manifests
 
       # Instead of `make VERSION="${RELEASE_TAG}" create-gh-release upload-gh-artifacts`, which requires GitHub CLI
       # authentication, use an action which does the same.


### PR DESCRIPTION
Failed after https://github.com/giantswarm/cluster-api-provider-aws/pull/607 because the release tooling / Makefile changed.

Towards https://github.com/giantswarm/roadmap/issues/3170.