### PR TITLE
✨ Avoid reconciling AWSMachinePools when only the status field has changed

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -34,7 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -214,6 +216,28 @@ func (r *AWSMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			handler.EnqueueRequestsFromMapFunc(machinePoolToInfrastructureMapFunc(expinfrav1.GroupVersion.WithKind("AWSMachinePool"))),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(logger.FromContext(ctx).GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(
+			predicate.Funcs{
+				// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates
+				// for AWSMachinePool resources only
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if e.ObjectOld.GetObjectKind().GroupVersionKind().Kind != "AWSMachinePool" {
+						return true
+					}
+
+					oldCluster := e.ObjectOld.(*expinfrav1.AWSMachinePool).DeepCopy()
+					newCluster := e.ObjectNew.(*expinfrav1.AWSMachinePool).DeepCopy()
+
+					oldCluster.Status = expinfrav1.AWSMachinePoolStatus{}
+					newCluster.Status = expinfrav1.AWSMachinePoolStatus{}
+
+					oldCluster.ObjectMeta.ResourceVersion = ""
+					newCluster.ObjectMeta.ResourceVersion = ""
+
+					return !cmp.Equal(oldCluster, newCluster)
+				},
+			},
+		).
 		Complete(r)
 }
 


### PR DESCRIPTION
Backporting https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5333