### PR TITLE
Only try to delete AWSMachine bootstrap data for non-machine pool machines

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -305,9 +305,11 @@ func (r *AWSMachineReconciler) reconcileDelete(machineScope *scope.MachineScope,
 
 	ec2Service := r.getEC2Service(ec2Scope)
 
-	if err := r.deleteBootstrapData(machineScope, clusterScope, objectStoreScope); err != nil {
-		machineScope.Error(err, "unable to delete machine")
-		return ctrl.Result{}, err
+	if !machineScope.IsMachinePoolMachine() {
+		if err := r.deleteBootstrapData(machineScope, clusterScope, objectStoreScope); err != nil {
+			machineScope.Error(err, "unable to delete AWSMachine bootstrap data")
+			return ctrl.Result{}, err
+		}
 	}
 
 	instance, err := r.findInstance(machineScope, ec2Service)


### PR DESCRIPTION
This fixes the error `invalid secret backend` because CAPA mistakenly tries to delete bootstrap data that won't ever exist for machine pool machines as their bootstrapping is done from another controller. See other places where `if !machineScope.IsMachinePoolMachine()` was already correctly used.

The fix is critical because currently, some clusters fail to continue deletion as the reconciliation logic is stopped at the mentioned error.