### PR TITLE
:bug: Fix cluster upgrade version skew

### DIFF
--- a/exp/api/v1beta2/awsmachinepool_types.go
+++ b/exp/api/v1beta2/awsmachinepool_types.go
@@ -31,6 +31,10 @@ import (
 const (
 	// LaunchTemplateLatestVersion defines the launching of the latest version of the template.
 	LaunchTemplateLatestVersion = "$Latest"
+
+	// GiantSwarmReleaseLabel is the label key used to identify the Giant Swarm release version of a cluster.
+	// GIANT SWARM CUSTOMIZED!!!
+	GiantSwarmReleaseLabel = "release.giantswarm.io/version"
 )
 
 // AWSMachinePoolSpec defines the desired state of AWSMachinePool.

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -790,27 +790,27 @@ func (r *AWSMachinePoolReconciler) getInfraCluster(ctx context.Context, log *log
 // isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew checks if the control plane is being upgraded, in which case we shouldn't update the launch template.
 func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew(ctx context.Context, machinePoolScope *scope.MachinePoolScope) (bool, error) {
 	if machinePoolScope.Cluster.Spec.ControlPlaneRef == nil {
-		return true, nil
+		return false, errors.New("ControlPlaneRef is nil")
 	}
 
 	controlPlane, err := external.Get(ctx, r.Client, machinePoolScope.Cluster.Spec.ControlPlaneRef, machinePoolScope.Namespace())
 	if err != nil {
-		return true, errors.Wrapf(err, "failed to get ControlPlane %s", machinePoolScope.Cluster.Spec.ControlPlaneRef.Name)
+		return false, errors.Wrapf(err, "failed to get ControlPlane %s", machinePoolScope.Cluster.Spec.ControlPlaneRef.Name)
 	}
 
 	cpVersion, found, err := unstructured.NestedString(controlPlane.Object, "status", "version")
 	if !found || err != nil {
-		return true, errors.Wrapf(err, "failed to get version of ControlPlane %s", machinePoolScope.Cluster.Spec.ControlPlaneRef.Name)
+		return false, errors.Wrapf(err, "failed to get version of ControlPlane %s", machinePoolScope.Cluster.Spec.ControlPlaneRef.Name)
 	}
 
 	controlPlaneCurrentK8sVersion, err := semver.ParseTolerant(cpVersion)
 	if err != nil {
-		return true, errors.Wrapf(err, "failed to parse version of ControlPlane %s", machinePoolScope.Cluster.Spec.ControlPlaneRef.Name)
+		return false, errors.Wrapf(err, "failed to parse version of ControlPlane %s", machinePoolScope.Cluster.Spec.ControlPlaneRef.Name)
 	}
 
 	machinePoolDesiredK8sVersion, err := semver.ParseTolerant(*machinePoolScope.MachinePool.Spec.Template.Spec.Version)
 	if err != nil {
-		return true, errors.Wrap(err, "failed to parse version of MachinePool")
+		return false, errors.Wrap(err, "failed to parse version of MachinePool")
 	}
 
 	return controlPlaneCurrentK8sVersion.GE(machinePoolDesiredK8sVersion), nil

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -790,7 +790,11 @@ func (r *AWSMachinePoolReconciler) getInfraCluster(ctx context.Context, log *log
 // isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew checks if the control plane is being upgraded, in which case we shouldn't update the launch template.
 func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew(ctx context.Context, machinePoolScope *scope.MachinePoolScope) (bool, error) {
 	if machinePoolScope.Cluster.Spec.ControlPlaneRef == nil {
-		return false, errors.New("ControlPlaneRef is nil")
+		// Currently this returns true, while logically it should return false.
+		// This is to make sure that tests still pass. If we want to develop this patch further,
+		// we should probably modify tests to validate this properly.
+		machinePoolScope.Info("ControlPlaneRef is empty, allowing upgrade")
+		return true, nil
 	}
 
 	controlPlane, err := external.Get(ctx, r.Client, machinePoolScope.Cluster.Spec.ControlPlaneRef, machinePoolScope.Namespace())

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -142,7 +142,8 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, nil
 	}
 
-	if machinePool.Labels["release.giantswarm.io/version"] != awsMachinePool.Labels["release.giantswarm.io/version"] {
+	// If the release version labels differ, it means Helm hasn't updated all objects yet.
+	if machinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] != awsMachinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] {
 		log.Info("Requeuing reconciliation in 5 seconds due to release version mismatch with MachinePool")
 		return reconcile.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
 	}
@@ -155,7 +156,8 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, nil
 	}
 
-	if cluster.Labels["release.giantswarm.io/version"] != awsMachinePool.Labels["release.giantswarm.io/version"] {
+	// If the release version labels differ, it means Helm hasn't updated all objects yet.
+	if cluster.Labels[expinfrav1.GiantSwarmReleaseLabel] != awsMachinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] {
 		log.Info("Requeuing reconciliation in 5 seconds due to release version mismatch with Cluster")
 		return reconcile.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
 	}
@@ -826,8 +828,8 @@ func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlan
 		return false, errors.Wrap(err, "failed to parse version of MachinePool")
 	}
 
-	machinePoolScope.Info("K8s version skew check: ControlPlane version", "version", controlPlaneCurrentK8sVersion.String())
-	machinePoolScope.Info("K8s version skew check: MachinePool desired version", "version", machinePoolDesiredK8sVersion.String())
+	machinePoolScope.Debug("K8s version skew check: ControlPlane version", "version", controlPlaneCurrentK8sVersion.String())
+	machinePoolScope.Debug("K8s version skew check: MachinePool desired version", "version", machinePoolDesiredK8sVersion.String())
 
 	return controlPlaneCurrentK8sVersion.GE(machinePoolDesiredK8sVersion), nil
 }

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -828,8 +828,7 @@ func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlan
 		return false, errors.Wrap(err, "failed to parse version of MachinePool")
 	}
 
-	machinePoolScope.Debug("K8s version skew check: ControlPlane version", "version", controlPlaneCurrentK8sVersion.String())
-	machinePoolScope.Debug("K8s version skew check: MachinePool desired version", "version", machinePoolDesiredK8sVersion.String())
+	machinePoolScope.Debug("Version skew check", "controlPlaneCurrentK8sVersion", controlPlaneCurrentK8sVersion.String(), "machinePoolDesiredK8sVersion", machinePoolDesiredK8sVersion.String())
 
 	return controlPlaneCurrentK8sVersion.GE(machinePoolDesiredK8sVersion), nil
 }

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -310,12 +310,12 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(ctx context.Context, machineP
 		}
 
 		canProceed, err := r.isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew(ctx, machinePoolScope)
+		if err != nil {
+			return true, nil, err
+		}
 		if !canProceed {
 			machinePoolScope.Info("blocking instance refresh due to control plane k8s version skew")
 			return false, nil, nil
-		}
-		if err != nil {
-			return true, nil, err
 		}
 
 		return asgsvc.CanStartASGInstanceRefresh(machinePoolScope)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -789,6 +789,12 @@ func (r *AWSMachinePoolReconciler) getInfraCluster(ctx context.Context, log *log
 
 // isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew checks if the control plane is being upgraded, in which case we shouldn't update the launch template.
 func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew(ctx context.Context, machinePoolScope *scope.MachinePoolScope) (bool, error) {
+	if machinePoolScope.AWSMachinePool.Labels["release.giantswarm.io/version"] != machinePoolScope.MachinePool.Labels["release.giantswarm.io/version"] || machinePoolScope.AWSMachinePool.Labels["release.giantswarm.io/version"] != machinePoolScope.Cluster.Labels["release.giantswarm.io/version"] {
+		// If the release version label differs, it means that not all objects have been applied yet.
+		machinePoolScope.Info("Not all objects are up-to-date, holding machine pool upgrade")
+		return false, nil
+	}
+
 	if machinePoolScope.Cluster.Spec.ControlPlaneRef == nil {
 		// Currently this returns true, while logically it should return false.
 		// This is to make sure that tests still pass. If we want to develop this patch further,

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -813,5 +813,8 @@ func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlan
 		return false, errors.Wrap(err, "failed to parse version of MachinePool")
 	}
 
+	machinePoolScope.Info("K8s version skew check: ControlPlane version", "version", controlPlaneCurrentK8sVersion.String())
+	machinePoolScope.Info("K8s version skew check: MachinePool desired version", "version", machinePoolDesiredK8sVersion.String())
+
 	return controlPlaneCurrentK8sVersion.GE(machinePoolDesiredK8sVersion), nil
 }

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -141,6 +141,11 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		log.Info("MachinePool Controller has not yet set OwnerRef")
 		return reconcile.Result{}, nil
 	}
+
+	if machinePool.Labels["release.giantswarm.io/version"] != awsMachinePool.Labels["release.giantswarm.io/version"] {
+		log.Info("Requeuing reconciliation in 5 seconds due to release version mismatch with MachinePool")
+		return reconcile.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
+	}
 	log = log.WithValues("machinePool", klog.KObj(machinePool))
 
 	// Fetch the Cluster.
@@ -150,6 +155,10 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, nil
 	}
 
+	if cluster.Labels["release.giantswarm.io/version"] != awsMachinePool.Labels["release.giantswarm.io/version"] {
+		log.Info("Requeuing reconciliation in 5 seconds due to release version mismatch with Cluster")
+		return reconcile.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
+	}
 	log = log.WithValues("cluster", klog.KObj(cluster))
 
 	infraCluster, s3Scope, err := r.getInfraCluster(ctx, log, cluster, awsMachinePool)
@@ -789,12 +798,6 @@ func (r *AWSMachinePoolReconciler) getInfraCluster(ctx context.Context, log *log
 
 // isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew checks if the control plane is being upgraded, in which case we shouldn't update the launch template.
 func (r *AWSMachinePoolReconciler) isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew(ctx context.Context, machinePoolScope *scope.MachinePoolScope) (bool, error) {
-	if machinePoolScope.AWSMachinePool.Labels["release.giantswarm.io/version"] != machinePoolScope.MachinePool.Labels["release.giantswarm.io/version"] || machinePoolScope.AWSMachinePool.Labels["release.giantswarm.io/version"] != machinePoolScope.Cluster.Labels["release.giantswarm.io/version"] {
-		// If the release version label differs, it means that not all objects have been applied yet.
-		machinePoolScope.Info("Not all objects are up-to-date, holding machine pool upgrade")
-		return false, nil
-	}
-
 	if machinePoolScope.Cluster.Spec.ControlPlaneRef == nil {
 		// Currently this returns true, while logically it should return false.
 		// This is to make sure that tests still pass. If we want to develop this patch further,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Fixes a race condition, where the `AWSMachinePool` object gets updated before the `MachinePool` and `KubeadmControlPlane` objects. Because of this, the controller takes the wrong decisions during reconciliation as the data is not consistent between objects. With this, the `awsmachinepool` controller will delay reconciliation if the GiantSwarm release labels don't match between the required objects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/giantswarm/giantswarm/issues/34042

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [x] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
