### PR TITLE
Ignore release drift while deleting MachinePool and AWSMachinePool

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -146,7 +146,9 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// If the release version labels differ, it means Helm hasn't updated all objects yet.
-	if machinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] != awsMachinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] {
+	// But it the machine pool is being deleted anyway, that does not matter.
+	if machinePool.DeletionTimestamp.IsZero() &&
+		machinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] != awsMachinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] {
 		log.Info("Requeuing reconciliation in 5 seconds due to release version mismatch with MachinePool")
 		return reconcile.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
 	}

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -160,7 +160,9 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// If the release version labels differ, it means Helm hasn't updated all objects yet.
-	if cluster.Labels[expinfrav1.GiantSwarmReleaseLabel] != awsMachinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] {
+	// But it the machine pool is being deleted anyway, that does not matter.
+	if awsMachinePool.DeletionTimestamp.IsZero() &&
+		cluster.Labels[expinfrav1.GiantSwarmReleaseLabel] != awsMachinePool.Labels[expinfrav1.GiantSwarmReleaseLabel] {
 		log.Info("Requeuing reconciliation in 5 seconds due to release version mismatch with Cluster")
 		return reconcile.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
 	}


### PR DESCRIPTION
The release drift check is meant to catch when the GitOps controller (through Helm or whatever) updates the AWSMachinePool before its corresponding Cluster during cluster upgrades. See https://github.com/giantswarm/giantswarm/issues/34042.

However, we noticed a situation where an AWSMachinePool was deleted _during_ a cluster upgrade. In this case, the AWSMachinePool is _never_ updated, and is instead deleted. Because the AWSMachinePool is never updated, the annotation is never updated either, and the reconciliation never proceeds. In this case, the drift does not matter, and CAPA should just proceed with the deletion.