### PR TITLE
Revert "Changed dedicated host validation logic to require tenancy = host"

### DIFF
--- a/webhooks/awsmachine_webhook.go
+++ b/webhooks/awsmachine_webhook.go
@@ -39,11 +39,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/feature"
 )
 
-const (
-	hostTenancy  = "host"
-	hostAffinity = "host"
-)
-
 // log is for logging in this package.
 var log = ctrl.Log.WithName("awsmachine-resource")
 
@@ -491,19 +486,6 @@ func (w *AWSMachine) validateHostAllocation(r *infrav1.AWSMachine) field.ErrorLi
 	// If both hostID and dynamicHostAllocation are specified, return an error
 	if hasHostID && hasDynamicHostAllocation {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostID"), "hostID and dynamicHostAllocation are mutually exclusive"), field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "hostID and dynamicHostAllocation are mutually exclusive"))
-	}
-
-	// HostID, HostAffinity, and DynamicHostAllocation can only be set when Tenancy is "host"
-	if hasHostID && r.Spec.Tenancy != hostTenancy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostID"), "hostID can only be set when tenancy is 'host'"))
-	}
-
-	if r.Spec.HostAffinity != nil && *r.Spec.HostAffinity == hostAffinity && r.Spec.Tenancy != hostTenancy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostAffinity"), "hostAffinity can only be set to 'host' when tenancy is 'host'"))
-	}
-
-	if hasDynamicHostAllocation && r.Spec.Tenancy != hostTenancy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when tenancy is 'host'"))
 	}
 
 	return allErrs

--- a/webhooks/awsmachine_webhook_test.go
+++ b/webhooks/awsmachine_webhook_test.go
@@ -484,7 +484,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 				},
 			},
@@ -495,7 +494,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 					HostID:       ptr.To("h-09dcf61cb388b0149"),
 				},
@@ -507,7 +505,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
 						Tags: map[string]string{"env": "test"},
@@ -531,7 +528,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("default"),
 					HostID:       ptr.To("h-09dcf61cb388b0149"),
 				},
@@ -543,7 +539,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("default"),
 					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
 						Tags: map[string]string{"env": "test"},
@@ -566,7 +561,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostID:       ptr.To("h-09dcf61cb388b0149"),
 				},
 			},
@@ -577,7 +571,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
 						Tags: map[string]string{"env": "test"},
 					},
@@ -590,7 +583,6 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 					HostID:       aws.String("h-1234567890abcdef0"),
 					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
@@ -607,48 +599,12 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
-					Tenancy:      "host",
 					HostAffinity: ptr.To("default"),
 					HostID:       aws.String("h-1234567890abcdef0"),
 					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
 						Tags: map[string]string{
 							"Environment": "test",
 						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "hostID without tenancy=host is invalid",
-			machine: &infrav1.AWSMachine{
-				Spec: infrav1.AWSMachineSpec{
-					InstanceType: "test",
-					Tenancy:      "default",
-					HostID:       ptr.To("h-09dcf61cb388b0149"),
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "hostAffinity=host without tenancy=host is invalid",
-			machine: &infrav1.AWSMachine{
-				Spec: infrav1.AWSMachineSpec{
-					InstanceType: "test",
-					Tenancy:      "default",
-					HostAffinity: ptr.To("host"),
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "dynamicHostAllocation without tenancy=host is invalid",
-			machine: &infrav1.AWSMachine{
-				Spec: infrav1.AWSMachineSpec{
-					InstanceType: "test",
-					Tenancy:      "dedicated",
-					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
-						Tags: map[string]string{"env": "test"},
 					},
 				},
 			},

--- a/webhooks/awsmachinetemplate_webhook.go
+++ b/webhooks/awsmachinetemplate_webhook.go
@@ -186,21 +186,8 @@ func (w *AWSMachineTemplate) validateHostAllocation(r *infrav1.AWSMachineTemplat
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostID"), "hostID and dynamicHostAllocation are mutually exclusive"), field.Forbidden(field.NewPath("spec.template.spec.dynamicHostAllocation"), "hostID and dynamicHostAllocation are mutually exclusive"))
 	}
 
-	// HostID, HostAffinity, and DynamicHostAllocation can only be set when Tenancy is "host"
-	if hasHostID && spec.Tenancy != hostTenancy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostID"), "hostID can only be set when tenancy is 'host'"))
-	}
-
-	if spec.HostAffinity != nil && *spec.HostAffinity == hostAffinity && spec.Tenancy != hostTenancy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostAffinity"), "hostAffinity can only be set to 'host' when tenancy is 'host'"))
-	}
-
-	if hasDynamicHostAllocation && spec.Tenancy != hostTenancy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when tenancy is 'host'"))
-	}
-
 	// When hostAffinity is "host", either hostID or dynamicHostAllocation must be specified
-	if spec.HostAffinity != nil && *spec.HostAffinity == hostAffinity && !hasHostID && !hasDynamicHostAllocation {
+	if spec.HostAffinity != nil && *spec.HostAffinity == "host" && !hasHostID && !hasDynamicHostAllocation {
 		allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.hostID"), "hostID or dynamicHostAllocation must be set when hostAffinity is 'host'"))
 	}
 

--- a/webhooks/awsmachinetemplate_webhook_test.go
+++ b/webhooks/awsmachinetemplate_webhook_test.go
@@ -90,7 +90,6 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: infrav1.AWSMachineTemplateResource{
 						Spec: infrav1.AWSMachineSpec{
 							InstanceType: "test",
-							Tenancy:      "host",
 							HostID:       aws.String("h-1234567890abcdef0"),
 							DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
 								Tags: map[string]string{
@@ -111,7 +110,6 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: infrav1.AWSMachineTemplateResource{
 						Spec: infrav1.AWSMachineSpec{
 							InstanceType: "test",
-							Tenancy:      "host",
 							HostAffinity: ptr.To("host"),
 						},
 					},
@@ -127,7 +125,6 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: infrav1.AWSMachineTemplateResource{
 						Spec: infrav1.AWSMachineSpec{
 							InstanceType: "test",
-							Tenancy:      "host",
 							HostAffinity: ptr.To("host"),
 							HostID:       ptr.To("h-09dcf61cb388b0149"),
 						},
@@ -144,7 +141,6 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: infrav1.AWSMachineTemplateResource{
 						Spec: infrav1.AWSMachineSpec{
 							InstanceType: "test",
-							Tenancy:      "host",
 							HostAffinity: ptr.To("host"),
 							DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
 								Tags: map[string]string{"env": "test"},
@@ -169,57 +165,6 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 				},
 			},
 			wantError: false,
-		},
-		{
-			name: "hostID without tenancy=host is invalid",
-			inputTemplate: &infrav1.AWSMachineTemplate{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: infrav1.AWSMachineTemplateSpec{
-					Template: infrav1.AWSMachineTemplateResource{
-						Spec: infrav1.AWSMachineSpec{
-							InstanceType: "test",
-							Tenancy:      "default",
-							HostID:       ptr.To("h-09dcf61cb388b0149"),
-						},
-					},
-				},
-			},
-			wantError: true,
-		},
-		{
-			name: "hostAffinity=host without tenancy=host is invalid",
-			inputTemplate: &infrav1.AWSMachineTemplate{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: infrav1.AWSMachineTemplateSpec{
-					Template: infrav1.AWSMachineTemplateResource{
-						Spec: infrav1.AWSMachineSpec{
-							InstanceType: "test",
-							Tenancy:      "default",
-							HostAffinity: ptr.To("host"),
-							HostID:       ptr.To("h-09dcf61cb388b0149"),
-						},
-					},
-				},
-			},
-			wantError: true,
-		},
-		{
-			name: "dynamicHostAllocation without tenancy=host is invalid",
-			inputTemplate: &infrav1.AWSMachineTemplate{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: infrav1.AWSMachineTemplateSpec{
-					Template: infrav1.AWSMachineTemplateResource{
-						Spec: infrav1.AWSMachineSpec{
-							InstanceType: "test",
-							Tenancy:      "dedicated",
-							DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
-								Tags: map[string]string{"env": "test"},
-							},
-						},
-					},
-				},
-			},
-			wantError: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This leads to errors like

```
"Reconciler error" err="failed to sync Machines: failed to update InfrastructureMachine org-mycluster/mycluster-5xtbq: failed to update AWSMachine: failed to apply AWSMachine org-mycluster/mycluster-5xtbq: admission webhook \"validation.awsmachine.infrastructure.cluster.x-k8s.io\" denied the request: AWSMachine.infrastructure.cluster.x-k8s.io \"mycluster-5xtbq\" is invalid: spec.hostAffinity: Forbidden: hostAffinity can only be set to 'host' when tenancy is 'host'" controller="kubeadmcontrolplane" controllerGroup="controlplane.cluster.x-k8s.io" controllerKind="KubeadmControlPlane" KubeadmControlPlane="org-mycluster/mycluster" namespace="org-mycluster" name="mycluster" reconcileID="ba7d2bb1-ebe5-4ef6-be8d-38c6b4a2f10e"
```

for existing clusters since their `AWSMachine` objects still have the old default `spec.hostAffinity=host` baked in.